### PR TITLE
Bump shedlock.version from 6.6.1 to 6.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 
 		<!-- Dependencies -->
 		<spring-boot.version>3.4.6</spring-boot.version>
-		<shedlock.version>6.6.1</shedlock.version>
+		<shedlock.version>6.7.0</shedlock.version>
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
Bumps `shedlock.version` from 6.6.1 to 6.7.0.

Updates `net.javacrumbs.shedlock:shedlock-provider-jdbc-template` from 6.6.1 to 6.7.0

Updates `net.javacrumbs.shedlock:shedlock-spring` from 6.6.1 to 6.7.0
- [Changelog](https://github.com/lukas-krecan/ShedLock/blob/master/RELEASES.md)
- [Commits](https://github.com/lukas-krecan/ShedLock/compare/shedlock-parent-6.6.1...shedlock-parent-6.7.0)

---
updated-dependencies:
- dependency-name: net.javacrumbs.shedlock:shedlock-provider-jdbc-template dependency-version: 6.7.0 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: net.javacrumbs.shedlock:shedlock-spring dependency-version: 6.7.0 dependency-type: direct:production update-type: version-update:semver-minor ...


(cherry picked from commit 18c8ebf3eaab20a2c4a252286a6bba68814b4b55)