### PR TITLE
Fix #423: Missing metadata for Sonatype (forward port)

### DIFF
--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -11,6 +11,7 @@
     </parent>
 
     <artifactId>annotations</artifactId>
+    <name>wultra-core-annotations</name>
     <description>Common annotations</description>
 
 </project>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -11,6 +11,7 @@
     </parent>
 
     <artifactId>core-bom</artifactId>
+    <name>wultra-core-bom</name>
     <description>Bill of Materials for Wultra Core</description>
     <packaging>pom</packaging>
 

--- a/http-common/pom.xml
+++ b/http-common/pom.xml
@@ -11,6 +11,7 @@
     </parent>
 
     <artifactId>http-common</artifactId>
+    <name>wultra-core-http</name>
     <description>Common HTTP functionality</description>
 
     <dependencies>


### PR DESCRIPTION
(cherry picked from commit 1ed54be2c7aa681518a1949d8c59f56ad382e340)