### PR TITLE
Fix #455: Configure annotationProcessorPaths for Lombok in maven-compiler-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,14 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>${maven-compiler-plugin.version}</version>
+					<configuration>
+						<annotationProcessorPaths>
+							<path>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok</artifactId>
+							</path>
+						</annotationProcessorPaths>
+					</configuration>
 				</plugin>
 
 				<plugin>


### PR DESCRIPTION
## Summary

Fixes Lombok annotation processing on Java 25 by explicitly registering Lombok via `annotationProcessorPaths` in `maven-compiler-plugin`.

Closes #455

## Problem

Starting with JDK 23, the default annotation processing policy changed to `none`. This causes compilation failures of Maven projects using Lombok — the `logger` field generated by `@Slf4j` and other members are not visible to `javac`:

```
cannot find symbol
  symbol: variable logger
```

CI (Java 21) is unaffected; the issue only manifests locally when using Java 25.

## Solution

Add explicit `annotationProcessorPaths` configuration to `maven-compiler-plugin` in the root `pom.xml`. This bypasses the implicit APT discovery and works correctly on Java 25.

See: wultra/enrollment-server#1781 for the same fix applied to `enrollment-server`.

## Changes

| File | Change |
|---|---|
| `pom.xml` | Added `annotationProcessorPaths` for Lombok in `maven-compiler-plugin` |